### PR TITLE
Consistent type imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,5 @@
     "sourceType": "module"
   },
   "plugins": ["@typescript-eslint"],
-  "rules": {}
+  "rules": { "@typescript-eslint/consistent-type-imports": "error" }
 }

--- a/src/app/components/ActionLink/ActionLink.stories.tsx
+++ b/src/app/components/ActionLink/ActionLink.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ActionLink from './ActionLink';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 import type { ActionLinkProps } from './ActionLink';
 
 export default {

--- a/src/app/components/Button/Button.tsx
+++ b/src/app/components/Button/Button.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import classes from './Button.module.css';
 
 type ButtonProps = {

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import styles from './Header.module.css';
 import BackButton from '../BackButton/BackButton';
 import BookmarkIcon from '../assets/BookmarkIcon';

--- a/src/app/components/MovieButton/MovieButton.stories.tsx
+++ b/src/app/components/MovieButton/MovieButton.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MovieButton from './MovieButton';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 import type { MovieButtonProps } from './MovieButton';
 
 export default {

--- a/src/app/components/RatingIcon/RatingIcon.stories.tsx
+++ b/src/app/components/RatingIcon/RatingIcon.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import RatingIcon from './RatingIcon';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 import type { RatingIconProps } from './RatingIcon';
 
 export default {

--- a/src/app/components/TagGroup/TagGroup.stories.tsx
+++ b/src/app/components/TagGroup/TagGroup.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import TagGroup from './TagGroup';
-import { Story } from '@storybook/react';
+import type { Story } from '@storybook/react';
 import type { TagGroupProps } from './TagGroup';
 
 export default {

--- a/src/app/components/Typography/Typography.tsx
+++ b/src/app/components/Typography/Typography.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import styles from './Typography.module.css';
 
 type TypographyProps = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { GENRES } from './genreMap';
+import type { GENRES } from './genreMap';
 
 export type MoviesFromAPI = {
   page?: number;


### PR DESCRIPTION
Added [this rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md) to have eslint check for consistent type imports. Imports where then fixed by running `npm exec --call "eslint . --fix"`
https://docs.npmjs.com/cli/v7/commands/npm-exec