### PR TITLE
✨ Add useLocalStorage

### DIFF
--- a/src/app/hooks/useLocalStorage.ts
+++ b/src/app/hooks/useLocalStorage.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+export default function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T) => void] {
+  const [storedValue, setStoredValue] = useState(() => {
+    try {
+      const item = localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T) => {
+    try {
+      setStoredValue(value);
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
[More info](https://reactwithhooks.netlify.app/docs/hooks-reference.html#lazy-initial-state) on why the arrow function is passed to `useState ` 
```
() => {
    try {
      const item = localStorage.getItem(key);
      return item ? JSON.parse(item) : initialValue;
    } catch (error) {
      console.log(error);
      return initialValue;
    }
  }
```
This will only be executed on first render. Checks if `key` exists in [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), returns its value if so or sets `key` with initialValue (passed as argument into useLocalStorage) as value

`setValue`, sets the internal state and replaces entry in localStorage.
Any functionality beyond replacing the entire entry will need an additional custom hook designed by you, which will make use of this hook.

fixes #53 